### PR TITLE
LevelNum patch update

### DIFF
--- a/assets/asm/base/main.asm
+++ b/assets/asm/base/main.asm
@@ -14,7 +14,7 @@ incsrc "../work/resource_labels.asm"
 
 ORG $05D8B7
     BRA +
-    NOP #3        ;the levelnum patch goes here in many ROMs, just skip over it
+    skip 3        ;the levelnum patch goes here in many ROMs, just skip over it
 +
     REP #$30
     LDA $0E        


### PR DESCRIPTION
Don't NOP the LevelNum patch inserted by other tools, instead just skip over it when assembling.
This prevents a (harmless but annoying) conflict that is always detected by Callisto when building a ROM that uses both PIXI and UberASM Tool.